### PR TITLE
do not create (remove) symbolic link for Windows environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN wget https://github.com/fhunleth/fwup/releases/download/v${FWUP_VERSION}/fwu
     apt-get install -y ./fwup_${FWUP_VERSION}_amd64.deb && \
     rm ./fwup_${FWUP_VERSION}_amd64.deb && \
     rm -rf /var/lib/apt/lists/*
-# Create (fake) symbolic link for Windows environment
-RUN ln -s fwup /usr/bin/fwup.exe
 
 # Install hex and rebar
 RUN mix local.hex --force


### PR DESCRIPTION
this fix could be done according to improvement of Nerves
https://github.com/nerves-project/nerves/pull/569

And more, Nerves v1.7.1 has been released with the above merge!:tada:
https://github.com/nerves-project/nerves/releases/tag/v1.7.1