### PR TITLE
Bump v0.2.4: change repo URL of fwup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 
 # Install fwup (https://github.com/fhunleth/fwup)
 ENV FWUP_VERSION="1.8.3"
-RUN wget https://github.com/fhunleth/fwup/releases/download/v${FWUP_VERSION}/fwup_${FWUP_VERSION}_amd64.deb && \
+RUN wget https://github.com/fwup-home/fwup/releases/download/v${FWUP_VERSION}/fwup_${FWUP_VERSION}_amd64.deb && \
     apt-get install -y ./fwup_${FWUP_VERSION}_amd64.deb && \
     rm ./fwup_${FWUP_VERSION}_amd64.deb && \
     rm -rf /var/lib/apt/lists/*
@@ -25,6 +25,6 @@ RUN wget https://github.com/fhunleth/fwup/releases/download/v${FWUP_VERSION}/fwu
 RUN mix local.hex --force
 RUN mix local.rebar --force
 # Install Mix environment for Nerves
-RUN mix archive.install hex nerves_bootstrap 1.10.1 --force
+RUN mix archive.install hex nerves_bootstrap 1.10.2 --force
 
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -49,23 +49,25 @@ root@9bc88d0fc7b8:/workspace# ls ~/.mix/*
 /root/.mix/rebar  /root/.mix/rebar3
 
 /root/.mix/archives:
-hex-0.21.1  nerves_bootstrap-1.10.1
+hex-0.21.1  nerves_bootstrap-1.10.2
 ```
 
 ## Expected tools/versions to be installed
 
 Each version number is for a pre-built image on Docker Hub. If you built the Docker container locally, please check them as described in parentheses.
 
-| Name | check method(s) | v0.2.3 | v0.2.2 | v0.2.1 | v0.2 | v0.1.x |
-|:---|:---|:---:|:---:|:---:|:---:|:---:|
-| Debian | `cat /etc/debian_version` | 10.7 | 10.7 | 10.7 | 10.6 | 10.6 |
-| Erlang/OTP | `erl -V` or <br> `mix hex.info` | 23.2.3 | 23.2.3 | 23.1.5 | 23.1.4 | 23.1.4 |
-| Elixir | `elixir -v` | 1.11.3-otp-23 | 1.11.3-otp-23 | 1.11.2-otp-23 | 1.11.2-otp-23 | 1.11.2-otp-23 |
-| Nerves | `mix nerves.info` | 1.7.3 | 1.7.2 | 1.7.1 | 1.7.1 | 1.7.0 |
-| nerves_bootstrap | `ls ~/.mix/*` | 1.10.1 | 1.10.1 | 1.10.1 | 1.10.0 | 1.10.0 |
-| hex | `ls ~/.mix/*` | 0.21.1 | 0.21.1 | 0.20.6 | 0.20.6 | 0.20.6 |
-| rebar/rebar3 | `rebar -V` <br> `rebar3 -v` | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/3.14.2 | 2.6.4/3.14.2 |
-| fwup | `fwup --version` | 1.8.3 | 1.8.3 | 1.8.3 | 1.8.2 | 1.8.2 |
+**Bold** means an update from the previous version.
+
+| Name | check method(s) | v0.2.4 | v0.2.3 | v0.2.2 | v0.2.1 | v0.2 | v0.1.x |
+|:---|:---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Debian | `cat /etc/debian_version` | **10.8** | 10.7 | 10.7 | **10.7** | 10.6 | 10.6 |
+| Erlang/OTP | `erl -V` or <br> `mix hex.info` | **23.2.5** | 23.2.3 | **23.2.3** | **23.1.5** | 23.1.4 | 23.1.4 |
+| Elixir | `elixir -v` | 1.11.3-otp-23 | 1.11.3-otp-23 | **1.11.3-otp-23** | 1.11.2-otp-23 | 1.11.2-otp-23 | 1.11.2-otp-23 |
+| Nerves | `mix nerves.info` | **1.7.4** | **1.7.3** | **1.7.2** | 1.7.1 | **1.7.1** | 1.7.0 |
+| nerves_bootstrap | `ls ~/.mix/*` | **1.10.2** | 1.10.1 | 1.10.1 | **1.10.1** | 1.10.0 | 1.10.0 |
+| hex | `ls ~/.mix/*` | 0.21.1 | 0.21.1 | **0.21.1** | 0.20.6 | 0.20.6 | 0.20.6 |
+| rebar/rebar3 | `rebar -V` <br> `rebar3 -v` | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/**3.14.3** | 2.6.4/3.14.2 | 2.6.4/3.14.2 |
+| fwup | `fwup --version` | 1.8.3 | 1.8.3 | 1.8.3 | **1.8.3** | 1.8.2 | 1.8.2 |
 
 ## Tips
 


### PR DESCRIPTION
- change repo URL of fwup :tada:
  - https://github.com/fwup-home/fwup
- Bump nerves_bootstrap to v1.10.2
- The version of Erlang/OTP is now 23.2.5