### PR TITLE
Bump v0.2.6 according to Nerves v1.7.6 released

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# docker-elixir 1.11.3
+# docker-elixir 1.11.4
 # https://hub.docker.com/_/elixir
-FROM elixir:1.11.3
+FROM elixir:1.11.4
 
 ENV DEBCONF_NOWARNINGS yes
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ root@9bc88d0fc7b8:/workspace# ls ~/.mix/*
 /root/.mix/rebar  /root/.mix/rebar3
 
 /root/.mix/archives:
-hex-0.21.1  nerves_bootstrap-1.10.2
+hex-0.21.2  nerves_bootstrap-1.10.2
 ```
 
 ## Expected tools/versions to be installed
@@ -58,16 +58,16 @@ Each version number is for a pre-built image on Docker Hub. If you built the Doc
 
 **Bold** means an update from the previous version.
 
-| Name | check method(s) | v0.2.5 | v0.2.4 | v0.2.3 | v0.2.2 | v0.2.1 | v0.2 | v0.1.x |
-|:---|:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Debian | `cat /etc/debian_version` | 10.8 | **10.8** | 10.7 | 10.7 | **10.7** | 10.6 | 10.6 |
-| [Erlang/OTP](https://github.com/erlang/otp) | `erl -V` or <br> `mix hex.info` | **23.2.7** | **23.2.5** | 23.2.3 | **23.2.3** | **23.1.5** | 23.1.4 | 23.1.4 |
-| [Elixir](https://github.com/elixir-lang/elixir) | `elixir -v` | 1.11.3-otp-23 | 1.11.3-otp-23 | 1.11.3-otp-23 | **1.11.3-otp-23** | 1.11.2-otp-23 | 1.11.2-otp-23 | 1.11.2-otp-23 |
-| [Nerves](https://github.com/nerves-project/nerves) | `mix nerves.info` | 1.7.4 | **1.7.4** | **1.7.3** | **1.7.2** | 1.7.1 | **1.7.1** | 1.7.0 |
-| [nerves_bootstrap](https://github.com/nerves-project/nerves_bootstrap) | `ls ~/.mix/*` | 1.10.2 | **1.10.2** | 1.10.1 | 1.10.1 | **1.10.1** | 1.10.0 | 1.10.0 |
-| [hex](https://github.com/hexpm/hex) | `ls ~/.mix/*` | 0.21.1 | 0.21.1 | 0.21.1 | **0.21.1** | 0.20.6 | 0.20.6 | 0.20.6 |
-| [rebar](https://github.com/rebar/rebar)/[rebar3](https://github.com/erlang/rebar3) | `rebar -V` <br> `rebar3 -v` | 2.6.4/**3.14.4** | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/**3.14.3** | 2.6.4/3.14.2 | 2.6.4/3.14.2 |
-| [fwup](https://github.com/fwup-home/fwup) | `fwup --version` | **1.8.4** | 1.8.3 | 1.8.3 | 1.8.3 | **1.8.3** | 1.8.2 | 1.8.2 |
+| Name | check method(s) | v0.2.6 | v0.2.5 | v0.2.4 | v0.2.3 | v0.2.2 | v0.2.1 | v0.2 | v0.1.x |
+|:---|:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Debian | `cat /etc/debian_version` | **10.9** | 10.8 | **10.8** | 10.7 | 10.7 | **10.7** | 10.6 | 10.6 |
+| [Erlang/OTP](https://github.com/erlang/otp) | `erl -V` or <br> `mix hex.info` | **23.3.4.1** | **23.2.7** | **23.2.5** | 23.2.3 | **23.2.3** | **23.1.5** | 23.1.4 | 23.1.4 |
+| [Elixir](https://github.com/elixir-lang/elixir) | `elixir -v` | **1.11.4-otp-23** | 1.11.3-otp-23 | 1.11.3-otp-23 | 1.11.3-otp-23 | **1.11.3-otp-23** | 1.11.2-otp-23 | 1.11.2-otp-23 | 1.11.2-otp-23 |
+| [Nerves](https://github.com/nerves-project/nerves) | `mix nerves.info` | **1.7.6** | 1.7.4 | **1.7.4** | **1.7.3** | **1.7.2** | 1.7.1 | **1.7.1** | 1.7.0 |
+| [nerves_bootstrap](https://github.com/nerves-project/nerves_bootstrap) | `ls ~/.mix/*` | 1.10.2 | 1.10.2 | **1.10.2** | 1.10.1 | 1.10.1 | **1.10.1** | 1.10.0 | 1.10.0 |
+| [hex](https://github.com/hexpm/hex) | `ls ~/.mix/*` | **0.21.2** | 0.21.1 | 0.21.1 | 0.21.1 | **0.21.1** | 0.20.6 | 0.20.6 | 0.20.6 |
+| [rebar](https://github.com/rebar/rebar)/[rebar3](https://github.com/erlang/rebar3) | `rebar -V` <br> `rebar3 -v` | 2.6.4/**3.16.1** | 2.6.4/**3.14.4** | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/3.14.3 | 2.6.4/**3.14.3** | 2.6.4/3.14.2 | 2.6.4/3.14.2 |
+| [fwup](https://github.com/fwup-home/fwup) | `fwup --version` | 1.8.4 | **1.8.4** | 1.8.3 | 1.8.3 | 1.8.3 | **1.8.3** | 1.8.2 | 1.8.2 |
 
 ## Tips
 


### PR DESCRIPTION
- Bump Nerves v1.7.6 🎉 
- Updated tools:
  - Debian (base image): 10.9
  - Erlang/OTP: 23.3.4.1
  - Elixir: 1.11.4-otp-23
  - hex: 0.21.2
  - rebar3: 3.16.1